### PR TITLE
Feature/user levels

### DIFF
--- a/daily_word_bot/app.py
+++ b/daily_word_bot/app.py
@@ -24,7 +24,10 @@ user_bot_commands = [
     BotCommand("/help", "Opens help section"),
     BotCommand("/start", "Starts sending words"),
     BotCommand("/stop", "Stops sending words"),
-    BotCommand("/blockedwords", "Shows your blocked words")
+    BotCommand("/blockedwords", "Shows your blocked words"),
+    BotCommand("/mylevels", "Shows the level of the words you want to be sent: beginner, intermediate or advanced"),
+    BotCommand("/addlevel", "Adds a level of the words you wish to receive"),
+    BotCommand("/removelevel", "Removes a level of the words you wish to receive"),
 ]
 
 available_commands_msg = utils.build_available_commands_msg(user_bot_commands)
@@ -104,6 +107,22 @@ class App:
             update.callback_query.edit_message_text(msg, reply_markup=reply_markup)
         else:
             update.message.reply_text(msg, reply_markup=reply_markup)
+    
+    def on_mylevels_callback(self, update: Update, context: CallbackContext) -> None:
+        # TODO: ADD FUNCTIONALITY
+        msg = f"You can see words that belong to the level X Y and Z"
+        update.message.reply_text(msg)
+
+    def on_removelevel_callback(self, update: Update, context: CallbackContext) -> None:
+        # TODO: ADD FUNCTIONALITY
+        msg = f"You removed level X from your levels"
+        update.message.reply_text(msg)
+
+    def on_addlevel_callback(self, update: Update, context: CallbackContext) -> None:
+        # TODO: ADD FUNCTIONALITY
+        # take into account strange cases such as having already that level
+        msg = f"You added level X to your levels"
+        update.message.reply_text(msg)
 
     def inline_keyboard_callbacks(self, update: Update, context: CallbackContext) -> None:  # pragma: no cover
         query = update.callback_query
@@ -138,6 +157,7 @@ class App:
                 self.on_get_blockwords_callback(update, context, is_inline_keyboard=True)
 
     def send_word(self, context: CallbackContext):  # pragma: no cover
+        # TODO: MODIFY FUNCTIONALITY
         users = self.dao.get_all_active_users()
         logger.info(f"sending words to {len(users)} users")
 
@@ -191,6 +211,9 @@ class App:
         dispatcher.add_handler(CommandHandler("users", self.on_users_callback))
         dispatcher.add_handler(CommandHandler("wordbankinfo", self.on_wordbankinfo_callback))
         dispatcher.add_handler(CommandHandler("blockedwords", self.on_get_blockwords_callback))
+        dispatcher.add_handler(CommandHandler("mylevels", self.on_mylevels_callback))
+        dispatcher.add_handler(CommandHandler("addlevel", self.on_addlevel_callback))
+        dispatcher.add_handler(CommandHandler("removelevel", self.on_addlevel_callback))
         dispatcher.add_handler(CallbackQueryHandler(self.inline_keyboard_callbacks))
 
         self.updater.start_polling()

--- a/daily_word_bot/app.py
+++ b/daily_word_bot/app.py
@@ -108,7 +108,7 @@ class App:
         else:
             update.message.reply_text(msg, reply_markup=reply_markup)
 
-    def on_mylevels_callback(self, update: Update, context: CallbackContext) -> None:
+    def on_mylevels_callback(self, update: Update, context: CallbackContext) -> None:  # pragma: no cover
         # get user information from the message
         message = update.message or update.callback_query.message
         chat_id = message.chat_id
@@ -118,7 +118,7 @@ class App:
         msg = "You will be sent words that are from the levels: " + ', '.join(levels)
         update.message.reply_text(msg)
 
-    def on_removelevel_callback(self, update: Update, context: CallbackContext) -> None:
+    def on_removelevel_callback(self, update: Update, context: CallbackContext) -> None:  # pragma: no cover
         # get user information from the message
         message = update.message or update.callback_query.message
         chat_id = message.chat_id
@@ -144,7 +144,7 @@ class App:
 
         update.message.reply_text(answer_msg)
 
-    def on_addlevel_callback(self, update: Update, context: CallbackContext) -> None:
+    def on_addlevel_callback(self, update: Update, context: CallbackContext) -> None:  # pragma: no cover
         # get user information from the message
         message = update.message or update.callback_query.message
         chat_id = message.chat_id

--- a/daily_word_bot/app.py
+++ b/daily_word_bot/app.py
@@ -145,10 +145,35 @@ class App:
         update.message.reply_text(answer_msg)
 
     def on_addlevel_callback(self, update: Update, context: CallbackContext) -> None:
-        # TODO: ADD FUNCTIONALITY
-        # take into account strange cases such as having already that level
-        msg = "You added level X to your levels"
-        update.message.reply_text(msg)
+        # get user information from the message
+        message = update.message or update.callback_query.message
+        chat_id = message.chat_id
+        # bot answer variable
+        answer_msg = ''
+
+        # look for the levels of the user in the db
+        levels = self.dao.get_user_levels(chat_id)
+
+        # extract level sent by the user
+        level_to_add = utils.get_level_from_command(message.text)
+
+        if (not level_to_add) or (level_to_add not in utils.POSSIBLE_USER_LEVELS):
+            # error message
+            error_msg = 'Sorry I did not understand the level you sent me 😕\n'
+            try_again = 'Possible levels are: '+', '.join(utils.POSSIBLE_USER_LEVELS)+'.'
+            answer_msg = error_msg + try_again
+        elif level_to_add in levels:
+            # error message
+            error_msg = 'Sorry you already have that level assigned 😕\n'
+            try_again = 'Your current levels are: '+', '.join(levels)+'.'
+            answer_msg = error_msg + try_again
+        else :
+            self.dao.add_user_level(chat_id,level_to_add)
+            current_levels = self.dao.get_user_levels(chat_id)
+            levels_text = 'Your levels now are: '+', '.join(current_levels)
+            answer_msg = 'The level '+ level_to_add + ' was added successfully 🙂\n' + levels_text
+              
+        update.message.reply_text(answer_msg)
 
     def inline_keyboard_callbacks(self, update: Update, context: CallbackContext) -> None:  # pragma: no cover
         query = update.callback_query

--- a/daily_word_bot/app.py
+++ b/daily_word_bot/app.py
@@ -57,8 +57,9 @@ class App:
     def on_start_callback(self, update: Update, context: CallbackContext, is_inline_keyboard=False) -> None:  # pragma: no cover
         message = update.message or update.callback_query.message
         chat_id = message.chat_id
+        # check if user laready has levels assigned
         levels = self.dao.get_user_levels(chat_id)
-        user_levels = levels if len(levels) > 0 else ['beginner', 'intermediate', 'advanced']
+        user_levels = levels if len(levels) > 0 else utils.POSSIBLE_USER_LEVELS
         self.dao.save_user(message, user_levels)
 
         msg = f"Hello {message.chat.first_name}! " + available_commands_msg
@@ -73,7 +74,11 @@ class App:
 
     def on_stop_callback(self, update: Update, context: CallbackContext, is_inline_keyboard=False) -> None:  # pragma: no cover
         message = update.message or update.callback_query.message
-        self.dao.set_user_inactive(message)
+        chat_id = message.chat_id
+        # check if user laready has levels assigned
+        levels = self.dao.get_user_levels(chat_id)
+        user_levels = levels if len(levels) > 0 else utils.POSSIBLE_USER_LEVELS
+        self.dao.set_user_inactive(message, user_levels)
 
         msg = "You will no longer receive words!\n...Unles you use /start"
         reply_markup = InlineKeyboardMarkup([
@@ -134,6 +139,7 @@ class App:
         # extract level sent by the user
         level_to_remove = utils.get_level_from_command(message.text)
 
+        # check if provided level is known or assigned to user
         if (not level_to_remove) or (level_to_remove not in levels):
             # error message
             error_msg = 'Sorry I did not understand the level you sent me 😕\n'
@@ -160,6 +166,7 @@ class App:
         # extract level sent by the user
         level_to_add = utils.get_level_from_command(message.text)
 
+        # check if provided level is known or not assigned to user
         if (not level_to_add) or (level_to_add not in utils.POSSIBLE_USER_LEVELS):
             # error message
             error_msg = 'Sorry I did not understand the level you sent me 😕\n'
@@ -223,7 +230,7 @@ class App:
                 msg: str = ''
 
                 if not word_data:
-                    msg = 'You have no more words to learn'
+                    msg = 'Du hast alles gelernt! - ¡Te lo has aprendido todo!'
                 else:
                     msg = utils.build_word_msg(word_data)
 

--- a/daily_word_bot/app.py
+++ b/daily_word_bot/app.py
@@ -109,8 +109,10 @@ class App:
             update.message.reply_text(msg, reply_markup=reply_markup)
 
     def on_mylevels_callback(self, update: Update, context: CallbackContext) -> None:
-        # TODO: ADD FUNCTIONALITY
-        msg = "You can see words that belong to the level X Y and Z"
+        message = update.message or update.callback_query.message
+        chat_id = message.chat_id
+        levels = self.dao.get_user_levels(chat_id)
+        msg = "You will be sent words that are from the levels: " + ', '.join(levels)
         update.message.reply_text(msg)
 
     def on_removelevel_callback(self, update: Update, context: CallbackContext) -> None:
@@ -157,7 +159,7 @@ class App:
                 self.on_get_blockwords_callback(update, context, is_inline_keyboard=True)
 
     def send_word(self, context: CallbackContext):  # pragma: no cover
-        # TODO: MODIFY FUNCTIONALITY
+        # TODO: MODIFY FUNCTIONALITY TO TAKE INTO ACCOUNT CASE WHERE NO WORDS TO BE SENT
         users = self.dao.get_all_active_users()
         logger.info(f"sending words to {len(users)} users")
 

--- a/daily_word_bot/app.py
+++ b/daily_word_bot/app.py
@@ -56,7 +56,10 @@ class App:
 
     def on_start_callback(self, update: Update, context: CallbackContext, is_inline_keyboard=False) -> None:  # pragma: no cover
         message = update.message or update.callback_query.message
-        self.dao.save_user(message)
+        chat_id = message.chat_id
+        levels = self.dao.get_user_levels(chat_id)
+        user_levels = levels if len(levels) > 0 else ['beginner', 'intermediate', 'advanced']
+        self.dao.save_user(message, user_levels)
 
         msg = f"Hello {message.chat.first_name}! " + available_commands_msg
         reply_markup = InlineKeyboardMarkup([

--- a/daily_word_bot/app.py
+++ b/daily_word_bot/app.py
@@ -57,7 +57,7 @@ class App:
     def on_start_callback(self, update: Update, context: CallbackContext, is_inline_keyboard=False) -> None:  # pragma: no cover
         message = update.message or update.callback_query.message
         chat_id = message.chat_id
-        # check if user laready has levels assigned
+        # check if user already has levels assigned
         levels = self.dao.get_user_levels(chat_id)
         user_levels = levels if len(levels) > 0 else utils.POSSIBLE_USER_LEVELS
         self.dao.save_user(message, user_levels)
@@ -75,7 +75,7 @@ class App:
     def on_stop_callback(self, update: Update, context: CallbackContext, is_inline_keyboard=False) -> None:  # pragma: no cover
         message = update.message or update.callback_query.message
         chat_id = message.chat_id
-        # check if user laready has levels assigned
+        # check if user already has levels assigned
         levels = self.dao.get_user_levels(chat_id)
         user_levels = levels if len(levels) > 0 else utils.POSSIBLE_USER_LEVELS
         self.dao.set_user_inactive(message, user_levels)

--- a/daily_word_bot/app.py
+++ b/daily_word_bot/app.py
@@ -134,14 +134,14 @@ class App:
         if (not level_to_remove) or (level_to_remove not in levels):
             # error message
             error_msg = 'Sorry I did not understand the level you sent me 😕\n'
-            try_again = 'Your current levels are: '+', '.join(levels)+'.'
+            try_again = 'Your current levels are: ' + ', '.join(levels) + '.'
             answer_msg = error_msg + try_again
-        else :
-            self.dao.remove_user_level(chat_id,level_to_remove)
+        else:
+            self.dao.remove_user_level(chat_id, level_to_remove)
             current_levels = self.dao.get_user_levels(chat_id)
-            levels_text = 'Your levels now are: '+', '.join(current_levels)
-            answer_msg = 'The level '+ level_to_remove + ' was removed successfully 🙂\n' + levels_text
-              
+            levels_text = 'Your levels now are: ' + ', '.join(current_levels)
+            answer_msg = 'The level ' + level_to_remove + ' was removed successfully 🙂\n' + levels_text
+
         update.message.reply_text(answer_msg)
 
     def on_addlevel_callback(self, update: Update, context: CallbackContext) -> None:
@@ -160,19 +160,19 @@ class App:
         if (not level_to_add) or (level_to_add not in utils.POSSIBLE_USER_LEVELS):
             # error message
             error_msg = 'Sorry I did not understand the level you sent me 😕\n'
-            try_again = 'Possible levels are: '+', '.join(utils.POSSIBLE_USER_LEVELS)+'.'
+            try_again = 'Possible levels are: ' + ', '.join(utils.POSSIBLE_USER_LEVELS) + '.'
             answer_msg = error_msg + try_again
         elif level_to_add in levels:
             # error message
             error_msg = 'Sorry you already have that level assigned 😕\n'
-            try_again = 'Your current levels are: '+', '.join(levels)+'.'
+            try_again = 'Your current levels are: ' + ', '.join(levels) + '.'
             answer_msg = error_msg + try_again
-        else :
-            self.dao.add_user_level(chat_id,level_to_add)
+        else:
+            self.dao.add_user_level(chat_id, level_to_add)
             current_levels = self.dao.get_user_levels(chat_id)
-            levels_text = 'Your levels now are: '+', '.join(current_levels)
-            answer_msg = 'The level '+ level_to_add + ' was added successfully 🙂\n' + levels_text
-              
+            levels_text = 'Your levels now are: ' + ', '.join(current_levels)
+            answer_msg = 'The level ' + level_to_add + ' was added successfully 🙂\n' + levels_text
+
         update.message.reply_text(answer_msg)
 
     def inline_keyboard_callbacks(self, update: Update, context: CallbackContext) -> None:  # pragma: no cover

--- a/daily_word_bot/app.py
+++ b/daily_word_bot/app.py
@@ -26,8 +26,8 @@ user_bot_commands = [
     BotCommand("/stop", "Stops sending words"),
     BotCommand("/blockedwords", "Shows your blocked words"),
     BotCommand("/mylevels", "Shows the level of the words you want to be sent: beginner, intermediate or advanced"),
-    BotCommand("/addlevel", "Adds a level of the words you wish to receive"),
-    BotCommand("/removelevel", "Removes a level of the words you wish to receive"),
+    BotCommand("/addlevel", "Adds to your levels a level of the words you wish to receive"),
+    BotCommand("/removelevel", "Removes from your levels a level of the words you wish to receive"),
 ]
 
 available_commands_msg = utils.build_available_commands_msg(user_bot_commands)

--- a/daily_word_bot/app.py
+++ b/daily_word_bot/app.py
@@ -107,21 +107,21 @@ class App:
             update.callback_query.edit_message_text(msg, reply_markup=reply_markup)
         else:
             update.message.reply_text(msg, reply_markup=reply_markup)
-    
+
     def on_mylevels_callback(self, update: Update, context: CallbackContext) -> None:
         # TODO: ADD FUNCTIONALITY
-        msg = f"You can see words that belong to the level X Y and Z"
+        msg = "You can see words that belong to the level X Y and Z"
         update.message.reply_text(msg)
 
     def on_removelevel_callback(self, update: Update, context: CallbackContext) -> None:
         # TODO: ADD FUNCTIONALITY
-        msg = f"You removed level X from your levels"
+        msg = "You removed level X from your levels"
         update.message.reply_text(msg)
 
     def on_addlevel_callback(self, update: Update, context: CallbackContext) -> None:
         # TODO: ADD FUNCTIONALITY
         # take into account strange cases such as having already that level
-        msg = f"You added level X to your levels"
+        msg = "You added level X to your levels"
         update.message.reply_text(msg)
 
     def inline_keyboard_callbacks(self, update: Update, context: CallbackContext) -> None:  # pragma: no cover

--- a/daily_word_bot/db.py
+++ b/daily_word_bot/db.py
@@ -12,6 +12,7 @@ class DAO:
         self.r: redis.Redis = redis.Redis(host=host, port=port)
 
     def save_user(self, message: Message):
+        # TODO: MODIFY LOGIC AND ADD LEVELS LIST
         chat_id: str = message.chat.id
         name: str = message.chat.first_name
         self.r.sadd("users", chat_id)
@@ -61,7 +62,18 @@ class DAO:
 
     def get_user_blocked_words(self, chat_id) -> typing.List[str]:
         return to_string_list(self.r.smembers(f"blockedWords-{chat_id}"))
+    
+    def get_user_levels(self, chat_id) -> typing.List[str]:
+        # TODO: ADD datbase retrieval call
+        return []
+    
+    def remove_user_level(self, chat_id, level) -> None:
+        # TODO: remove user level from db
+        return 0
 
+    def add_user_level(self, chat_id, level) -> None:
+        # TODO: ADD level to user words level
+        return 0
 
 TypeSmembers = typing.Set[typing.Union[bytes, float, int, str]]
 

--- a/daily_word_bot/db.py
+++ b/daily_word_bot/db.py
@@ -15,11 +15,13 @@ class DAO:
         # TODO: MODIFY LOGIC AND ADD LEVELS LIST
         chat_id: str = message.chat.id
         name: str = message.chat.first_name
+        levels: list = ['beginner', 'intermediate', 'advanced']
         self.r.sadd("users", chat_id)
 
         user_info = json.dumps(dict(
             name=name,
-            isActive=True
+            isActive=True,
+            levels=levels
         ))
         self.r.set(f"userInfo:{chat_id}", user_info)
 
@@ -62,11 +64,11 @@ class DAO:
 
     def get_user_blocked_words(self, chat_id) -> typing.List[str]:
         return to_string_list(self.r.smembers(f"blockedWords-{chat_id}"))
-    
+
     def get_user_levels(self, chat_id) -> typing.List[str]:
         # TODO: ADD datbase retrieval call
         return []
-    
+
     def remove_user_level(self, chat_id, level) -> None:
         # TODO: remove user level from db
         return 0
@@ -74,6 +76,7 @@ class DAO:
     def add_user_level(self, chat_id, level) -> None:
         # TODO: ADD level to user words level
         return 0
+
 
 TypeSmembers = typing.Set[typing.Union[bytes, float, int, str]]
 

--- a/daily_word_bot/db.py
+++ b/daily_word_bot/db.py
@@ -12,7 +12,6 @@ class DAO:
         self.r: redis.Redis = redis.Redis(host=host, port=port)
 
     def save_user(self, message: Message):
-        # TODO: MODIFY LOGIC AND ADD LEVELS LIST
         chat_id: str = message.chat.id
         name: str = message.chat.first_name
         levels: list = ['beginner', 'intermediate', 'advanced']
@@ -26,6 +25,7 @@ class DAO:
         self.r.set(f"userInfo:{chat_id}", user_info)
 
     def set_user_inactive(self, message: Message):
+        # TODO : MODIFY LOGIC ADD LEVELS RETRIEVED FROM DB
         chat_id: str = message.chat.id
         name: str = message.chat.first_name
 
@@ -66,16 +66,24 @@ class DAO:
         return to_string_list(self.r.smembers(f"blockedWords-{chat_id}"))
 
     def get_user_levels(self, chat_id) -> typing.List[str]:
-        # TODO: ADD datbase retrieval call
-        return []
+        user_info = self.get_user(chat_id)
+        return user_info["levels"]
 
     def remove_user_level(self, chat_id, level) -> None:
-        # TODO: remove user level from db
-        return 0
+        user_info = self.get_user(chat_id)
+        levels = user_info["levels"]
+        levels.remove(level)
+        user_info["levels"] = levels
+        user_info = json.dumps(user_info)
+        self.r.set(f"userInfo:{chat_id}", user_info)
 
     def add_user_level(self, chat_id, level) -> None:
-        # TODO: ADD level to user words level
-        return 0
+        user_info = self.get_user(chat_id)
+        levels = user_info["levels"]
+        levels.append(level)
+        user_info["levels"] = levels
+        user_info = json.dumps(user_info)
+        self.r.set(f"userInfo:{chat_id}", user_info)
 
 
 TypeSmembers = typing.Set[typing.Union[bytes, float, int, str]]

--- a/daily_word_bot/db.py
+++ b/daily_word_bot/db.py
@@ -25,13 +25,14 @@ class DAO:
         self.r.set(f"userInfo:{chat_id}", user_info)
 
     def set_user_inactive(self, message: Message):
-        # TODO : MODIFY LOGIC ADD LEVELS RETRIEVED FROM DB
         chat_id: str = message.chat.id
         name: str = message.chat.first_name
+        levels: list = self.get_user_levels(chat_id)
 
         user_info = json.dumps(dict(
             name=name,
-            isActive=False
+            isActive=False,
+            levels=levels
         ))
         self.r.set(f"userInfo:{chat_id}", user_info)
 

--- a/daily_word_bot/utils.py
+++ b/daily_word_bot/utils.py
@@ -9,6 +9,20 @@ def highlight(w: str) -> str:
     return f"<b>{w}</b>"
 
 
+def get_level_from_command(command: str) -> str:
+    # variable to store the extracted level from the command
+    extracted_level = ''
+
+    # command parts sent by the user
+    command_parts = command.split(maxsplit=1)
+
+    # check result of the split
+    if len(command_parts) == 2: # if user specified a level
+        extracted_level = command_parts[1]
+        
+    return extracted_level
+
+
 def get_terms_without_articles(terms: str) -> typing.List[str]:
     # quitar artculos
     regex = r"die |das |der |el |la "

--- a/daily_word_bot/utils.py
+++ b/daily_word_bot/utils.py
@@ -6,6 +6,7 @@ from daily_word_bot import utils
 
 POSSIBLE_USER_LEVELS: list = ['beginner', 'intermediate', 'advanced']
 
+
 def highlight(w: str) -> str:
     return f"<b>{w}</b>"
 
@@ -18,9 +19,9 @@ def get_level_from_command(command: str) -> str:
     command_parts = command.split(maxsplit=1)
 
     # check result of the split
-    if len(command_parts) == 2: # if user specified a level
+    if len(command_parts) == 2:  # if user specified a level
         extracted_level = command_parts[1]
-        
+
     return extracted_level
 
 

--- a/daily_word_bot/utils.py
+++ b/daily_word_bot/utils.py
@@ -4,6 +4,7 @@ from telegram import BotCommand
 
 from daily_word_bot import utils
 
+POSSIBLE_USER_LEVELS: list = ['beginner', 'intermediate', 'advanced']
 
 def highlight(w: str) -> str:
     return f"<b>{w}</b>"

--- a/daily_word_bot/word_bank.py
+++ b/daily_word_bot/word_bank.py
@@ -46,13 +46,16 @@ class WordBank:
         self.df = df
         self.last_updated_at = str(datetime.now())
 
-    def get_random(self, exclude: list = []) -> dict:
-        # TODO : MODIFY LOGIC TO JUST GET A RANDOM WORD OF CERTAIN LEVELS
+    def get_random(self, exclude: list = [], levels: list = []) -> dict:
         """Get a random word excluding the provided ones"""
         if len(exclude) >= len(self.df.index):
             exclude = []
 
-        df_candidates = self.df.loc[~self.df.index.isin(exclude)]
+        df_candidates = self.df.loc[(~self.df.index.isin(exclude)) & (self.df['level'].isin(levels))]
+
+        if len(df_candidates.index) == 0:
+            return {"msg": "You have no more words to learn"}
+
         row = df_candidates.sample().iloc[0]
 
         examples: typing.List[dict] = []

--- a/daily_word_bot/word_bank.py
+++ b/daily_word_bot/word_bank.py
@@ -47,7 +47,7 @@ class WordBank:
         self.last_updated_at = str(datetime.now())
 
     def get_random(self, exclude: list = [], levels: list = []) -> dict:
-        """Get a random word excluding the provided ones"""
+        """Get a random word excluding the provided ones and taking into account the user levels"""
         if len(exclude) >= len(self.df.index):
             exclude = []
 

--- a/daily_word_bot/word_bank.py
+++ b/daily_word_bot/word_bank.py
@@ -54,7 +54,7 @@ class WordBank:
         df_candidates = self.df.loc[(~self.df.index.isin(exclude)) & (self.df['level'].isin(levels))]
 
         if len(df_candidates.index) == 0:
-            return {"msg": "You have no more words to learn"}
+            return {}
 
         row = df_candidates.sample().iloc[0]
 

--- a/daily_word_bot/word_bank.py
+++ b/daily_word_bot/word_bank.py
@@ -46,7 +46,7 @@ class WordBank:
         self.df = df
         self.last_updated_at = str(datetime.now())
 
-    def get_random(self, exclude: list = [], levels) -> dict:
+    def get_random(self, exclude: list = []) -> dict:
         # TODO : MODIFY LOGIC TO JUST GET A RANDOM WORD OF CERTAIN LEVELS
         """Get a random word excluding the provided ones"""
         if len(exclude) >= len(self.df.index):

--- a/daily_word_bot/word_bank.py
+++ b/daily_word_bot/word_bank.py
@@ -46,7 +46,8 @@ class WordBank:
         self.df = df
         self.last_updated_at = str(datetime.now())
 
-    def get_random(self, exclude: list = []) -> dict:
+    def get_random(self, exclude: list = [], levels) -> dict:
+        # TODO : MODIFY LOGIC TO JUST GET A RANDOM WORD OF CERTAIN LEVELS
         """Get a random word excluding the provided ones"""
         if len(exclude) >= len(self.df.index):
             exclude = []

--- a/tests/resources/word_bank.csv
+++ b/tests/resources/word_bank.csv
@@ -1,6 +1,6 @@
-word_id;Deutsch;Deutscher Ausdruck 1;Deutscher Ausdruck 2;Deutscher Ausdruck 3;Deutscher Ausdruck 4;Spanisch;Spanischer Ausdruck 1;Spanischer Ausdruck 2;Spanischer Ausdruck 3;Spanischer Ausdruck 4
-WID1;ab und zu;Vielleicht darf ich ihn mir ab und zu ausleihen;;;;de vez en cuando;Tal vez me lo puedes prestar de vez en cuando.;;;
-WID2;abändern;Niemand will die Genfer Konvention abändern, aber wir können die Konvention ergänzen.;;;;modificar;Nadie quiere modificar el Convenio de Ginebra, pero sí que podemos complementarlo.;;;
-WID3;abdrehen;Wir müssen einen Hahn abdrehen, der ständig offen ist.;;;;cerrar;Es preciso cerrar un grifo permanentemente abierto.;;;
-WID4;abhalten;Trotzdem, selbst das sollte Dich nicht abhalten.;Ich könnte bis in diese Nacht zurück und sie abhalten, mich wegzugeben.;;;impedir/detener;De todas formas, eso no debería detenerte.;Puedo regresar a aquella noche e impedir que me deje.;;
-WID5;abholen;Seine Wäsche steht zum Abholen bereit.;Wenn du mich abholst, bin ich deine beste Freundin.;;;recoger/venir a buscar;Su colada está lista para recoger.;Si me vienes a buscar, seré tu mejor amiga.;;
+word_id;level;Deutsch;Deutscher Ausdruck 1;Deutscher Ausdruck 2;Deutscher Ausdruck 3;Deutscher Ausdruck 4;Spanisch;Spanischer Ausdruck 1;Spanischer Ausdruck 2;Spanischer Ausdruck 3;Spanischer Ausdruck 4
+WID1;intermediate;ab und zu;Vielleicht darf ich ihn mir ab und zu ausleihen;;;;de vez en cuando;Tal vez me lo puedes prestar de vez en cuando.;;;
+WID2;intermediate;abändern;Niemand will die Genfer Konvention abändern, aber wir können die Konvention ergänzen.;;;;modificar;Nadie quiere modificar el Convenio de Ginebra, pero sí que podemos complementarlo.;;;
+WID3;beginner;abdrehen;Wir müssen einen Hahn abdrehen, der ständig offen ist.;;;;cerrar;Es preciso cerrar un grifo permanentemente abierto.;;;
+WID4;advanced;abhalten;Trotzdem, selbst das sollte Dich nicht abhalten.;Ich könnte bis in diese Nacht zurück und sie abhalten, mich wegzugeben.;;;impedir/detener;De todas formas, eso no debería detenerte.;Puedo regresar a aquella noche e impedir que me deje.;;
+WID5;beginner;abholen;Seine Wäsche steht zum Abholen bereit.;Wenn du mich abholst, bin ich deine beste Freundin.;;;recoger/venir a buscar;Su colada está lista para recoger.;Si me vienes a buscar, seré tu mejor amiga.;;

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -13,7 +13,7 @@ chat_id = "123"
 test_user_info = dict(
     name="Pepe",
     isActive=True,
-    levels=['beginner', 'intermediate', 'advanced']
+    levels=utils.POSSIBLE_USER_LEVELS
 )
 dao = DAO(config.REDIS_HOST)
 dao.r = fakeredis.FakeStrictRedis()

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -5,6 +5,7 @@ from telegram import Message, Chat
 
 from daily_word_bot.config import config
 from daily_word_bot.db import DAO
+from daily_word_bot import utils
 
 tc = unittest.TestCase()
 
@@ -25,7 +26,7 @@ message = Message(message_id=123456789, date="",
 
 def test_save_user():
     levels = dao.get_user_levels(chat_id)
-    user_levels = levels if len(levels) > 0 else ['beginner', 'intermediate', 'advanced']
+    user_levels = levels if len(levels) > 0 else utils.POSSIBLE_USER_LEVELS
     dao.save_user(message, user_levels)
     user_info = dao.get_user(chat_id)
     active_users = dao.get_all_user_ids()
@@ -37,7 +38,7 @@ def test_save_user():
 
 def test_get_all_users():
     levels = dao.get_user_levels(chat_id)
-    user_levels = levels if len(levels) > 0 else ['beginner', 'intermediate', 'advanced']
+    user_levels = levels if len(levels) > 0 else utils.POSSIBLE_USER_LEVELS
     dao.save_user(message, user_levels)
     users = list(dao.get_all_users())
     tc.assertIn(dict(test_user_info, chatId=chat_id), users)
@@ -46,7 +47,7 @@ def test_get_all_users():
 
 def test_set_user_inactive():
     levels = dao.get_user_levels(chat_id)
-    user_levels = levels if len(levels) > 0 else ['beginner', 'intermediate', 'advanced']
+    user_levels = levels if len(levels) > 0 else utils.POSSIBLE_USER_LEVELS
     dao.save_user(message, user_levels)
     active_users = dao.get_all_active_users()
     tc.assertIn(dict(test_user_info, chatId=chat_id), active_users)
@@ -69,11 +70,11 @@ def test_set_get_remove_user_bocked_words():
 
 
 def test_get_add_remove_user_level():
-    levels_to_remove = ['beginner', 'intermediate', 'advanced']
+    levels_to_remove = utils.POSSIBLE_USER_LEVELS
     level_to_add = 'advanced'
     test_levels = test_user_info["levels"]
     levels = dao.get_user_levels(chat_id)
-    user_levels = levels if len(levels) > 0 else ['beginner', 'intermediate', 'advanced']
+    user_levels = levels if len(levels) > 0 else utils.POSSIBLE_USER_LEVELS
 
     dao.save_user(message, user_levels)
 

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -24,7 +24,9 @@ message = Message(message_id=123456789, date="",
 
 
 def test_save_user():
-    dao.save_user(message)
+    levels = dao.get_user_levels(chat_id)
+    user_levels = levels if len(levels) > 0 else ['beginner', 'intermediate', 'advanced']
+    dao.save_user(message, user_levels)
     user_info = dao.get_user(chat_id)
     active_users = dao.get_all_user_ids()
 
@@ -34,18 +36,22 @@ def test_save_user():
 
 
 def test_get_all_users():
-    dao.save_user(message)
+    levels = dao.get_user_levels(chat_id)
+    user_levels = levels if len(levels) > 0 else ['beginner', 'intermediate', 'advanced']
+    dao.save_user(message, user_levels)
     users = list(dao.get_all_users())
     tc.assertIn(dict(test_user_info, chatId=chat_id), users)
     dao.r.flushall()
 
 
 def test_set_user_inactive():
-    dao.save_user(message)
+    levels = dao.get_user_levels(chat_id)
+    user_levels = levels if len(levels) > 0 else ['beginner', 'intermediate', 'advanced']
+    dao.save_user(message, user_levels)
     active_users = dao.get_all_active_users()
     tc.assertIn(dict(test_user_info, chatId=chat_id), active_users)
 
-    dao.set_user_inactive(message)
+    dao.set_user_inactive(message, user_levels)
     active_users = dao.get_all_active_users()
     tc.assertEqual([], active_users)
 
@@ -66,8 +72,10 @@ def test_get_add_remove_user_level():
     levels_to_remove = ['beginner', 'intermediate', 'advanced']
     level_to_add = 'advanced'
     test_levels = test_user_info["levels"]
+    levels = dao.get_user_levels(chat_id)
+    user_levels = levels if len(levels) > 0 else ['beginner', 'intermediate', 'advanced']
 
-    dao.save_user(message)
+    dao.save_user(message, user_levels)
 
     for level_to_remove in levels_to_remove:
         dao.remove_user_level(chat_id, level_to_remove)

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -60,3 +60,38 @@ def test_set_get_remove_user_bocked_words():
     tc.assertEqual(blocked_words, [])
 
     dao.r.flushall()
+
+
+def test_get_user_levels():
+    dao.save_user(message)
+    levels = dao.get_user_levels(chat_id)
+    tc.assertEqual(test_user_info["levels"], levels)
+
+
+def test_remove_user_level():
+    level_to_remove = 'beginner'
+    dao.save_user(message)
+    dao.remove_user_level(chat_id, level_to_remove)
+    levels = dao.get_user_levels(chat_id)
+    test_levels = test_user_info["levels"]
+    test_levels.remove(level_to_remove)
+    tc.assertEqual(test_levels, levels)
+
+
+def test_add_user_level():
+    levels_to_remove = ['beginner', 'intermediate', 'advanced']
+    level_to_add = 'advanced'
+    test_levels = test_user_info["levels"]
+    test_levels.append('beginner')
+
+    dao.save_user(message)
+
+    for level_to_remove in levels_to_remove:
+        dao.remove_user_level(chat_id, level_to_remove)
+        test_levels.remove(level_to_remove)
+
+    dao.add_user_level(chat_id, level_to_add)
+    test_levels.append(level_to_add)
+    levels = dao.get_user_levels(chat_id)
+
+    tc.assertEqual(test_levels, levels)

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -11,7 +11,8 @@ tc = unittest.TestCase()
 chat_id = "123"
 test_user_info = dict(
     name="Pepe",
-    isActive=True
+    isActive=True,
+    levels=['beginner', 'intermediate', 'advanced']
 )
 dao = DAO(config.REDIS_HOST)
 dao.r = fakeredis.FakeStrictRedis()

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -62,27 +62,10 @@ def test_set_get_remove_user_bocked_words():
     dao.r.flushall()
 
 
-def test_get_user_levels():
-    dao.save_user(message)
-    levels = dao.get_user_levels(chat_id)
-    tc.assertEqual(test_user_info["levels"], levels)
-
-
-def test_remove_user_level():
-    level_to_remove = 'beginner'
-    dao.save_user(message)
-    dao.remove_user_level(chat_id, level_to_remove)
-    levels = dao.get_user_levels(chat_id)
-    test_levels = test_user_info["levels"]
-    test_levels.remove(level_to_remove)
-    tc.assertEqual(test_levels, levels)
-
-
-def test_add_user_level():
+def test_get_add_remove_user_level():
     levels_to_remove = ['beginner', 'intermediate', 'advanced']
     level_to_add = 'advanced'
     test_levels = test_user_info["levels"]
-    test_levels.append('beginner')
 
     dao.save_user(message)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -85,3 +85,9 @@ def test_build_users_msg():
                    "Users: (2)"
                    "\n- aChatId romanito 😀"
                    "\n- aChatId2 pinxulino 😴")
+
+
+def test_get_level_from_command():
+    test_command = '/addorremovelevel beginner'
+    extracted_level = utils.get_level_from_command(test_command)
+    tc.assertEqual(extracted_level, 'beginner')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,6 +88,12 @@ def test_build_users_msg():
 
 
 def test_get_level_from_command():
+    # normal case
     test_command = '/addorremovelevel beginner'
-    extracted_level = utils.get_level_from_command(test_command)
-    tc.assertEqual(extracted_level, 'beginner')
+    extracted_level_1 = utils.get_level_from_command(test_command)
+    tc.assertEqual(extracted_level_1, 'beginner')
+
+    # no parameter case
+    test_command_2 = '/addorremovelevel'
+    extracted_level_2 = utils.get_level_from_command(test_command_2)
+    tc.assertEqual(extracted_level_2, '')

--- a/tests/test_word_bank.py
+++ b/tests/test_word_bank.py
@@ -10,6 +10,10 @@ def test_word_bank():
     random_word = word_bank.get_random(exclude=["WID1", "WID2", "WID3", "WID4"], levels=['beginner', 'intermediate', 'advanced'])
     tc.assertEqual(random_word.get("word_id"), "WID5")
 
+    word_bank = WordBank(local=True, local_path="tests/resources/word_bank.csv")
+    random_word = word_bank.get_random(exclude=["WID1", "WID2", "WID3", "WID4"], levels=['advanced'])
+    tc.assertEqual(random_word.get("msg"), "You have no more words to learn")
+
     random_word = word_bank.get_random(exclude=["WID1", "WID2", "WID3", "WID4", "WID5"], levels=['intermediate'])
     tc.assertIn("word_id", random_word)
     tc.assertIn("es", random_word)

--- a/tests/test_word_bank.py
+++ b/tests/test_word_bank.py
@@ -7,10 +7,10 @@ tc = unittest.TestCase()
 
 def test_word_bank():
     word_bank = WordBank(local=True, local_path="tests/resources/word_bank.csv")
-    random_word = word_bank.get_random(exclude=["WID1", "WID2", "WID3", "WID4"])
+    random_word = word_bank.get_random(exclude=["WID1", "WID2", "WID3", "WID4"], levels=['beginner', 'intermediate', 'advanced'])
     tc.assertEqual(random_word.get("word_id"), "WID5")
 
-    random_word = word_bank.get_random(exclude=["WID1", "WID2", "WID3", "WID4", "WID5"])
+    random_word = word_bank.get_random(exclude=["WID1", "WID2", "WID3", "WID4", "WID5"], levels=['intermediate'])
     tc.assertIn("word_id", random_word)
     tc.assertIn("es", random_word)
     tc.assertIn("de", random_word)

--- a/tests/test_word_bank.py
+++ b/tests/test_word_bank.py
@@ -12,7 +12,7 @@ def test_word_bank():
 
     word_bank = WordBank(local=True, local_path="tests/resources/word_bank.csv")
     random_word = word_bank.get_random(exclude=["WID1", "WID2", "WID3", "WID4"], levels=['advanced'])
-    tc.assertEqual(random_word.get("msg"), "You have no more words to learn")
+    tc.assertEqual(random_word, {})
 
     random_word = word_bank.get_random(exclude=["WID1", "WID2", "WID3", "WID4", "WID5"], levels=['intermediate'])
     tc.assertIn("word_id", random_word)


### PR DESCRIPTION
Added **user levels feature**. It consists in adding to the users one more configuration parameter for their dailyWord-bot, which is the level of the words they want to be sent. The **possible levels** are: **beginner, intermediate and advanced**.

The user has now **three new commands** available:

- **/mylevels** : Which returns the user's preference list of word levels.
- **/addlevel**: Which lets the user add one level of words to his preference list of word levels.
- **/removelevel**: Which lets the user remove one level of words from his preference list of word levels.

This new **feature** has direct **effects** to the **word bank spreadsheet**. It is needed to be added a **new column** called **level** between word_id and Deutsch which will indicate the level of the word **for each row**. So if this feature is wanted to be implemented there are two things needed to do after the merge to the main project:

1.  **Edit the word bank production spreadsheet**. Add the column level and assign one of the possible levels (beginner, intermediate or advanced) to each of the spreadsheet words.
2. **Ask the users to restart the bot** (call /stop and then /start) so they get assigned a default list of levels (which will be all levels) so then they can play and tweak it around.